### PR TITLE
Fix: Aba Agenda reseta para data atual ao ser selecionada

### DIFF
--- a/index.html
+++ b/index.html
@@ -1261,8 +1261,21 @@
                     tabContents.forEach(content => content.classList.add('hidden'));
                     const tabId = tab.dataset.tab;
                     document.getElementById(`${tabId}-section`).classList.remove('hidden');
-                    if (tabId === 'semana') renderWeekView();
-                    else if (tabId === 'relatorios') updateStatistics();
+
+                    if (tabId === 'agenda') {
+                        currentDate = new Date(); // Resetar para data de hoje
+                        updateDateDisplay();
+                        renderTasks();
+                    } else if (tabId === 'semana') {
+                        // Ao mudar para aba semana, garantir que currentDate seja ajustada para Segunda e a view atualizada
+                        const dayOfWeek = currentDate.getDay();
+                        const diffToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+                        currentDate.setDate(currentDate.getDate() + diffToMonday);
+                        updateDateDisplay(); // Atualizar display de data para o intervalo da semana
+                        renderWeekView();
+                    } else if (tabId === 'relatorios') {
+                        updateStatistics();
+                    }
                 });
             });
 


### PR DESCRIPTION
Modifica o event listener das abas para que, ao selecionar a aba 'Agenda', a `currentDate` seja redefinida para a data de hoje. Isso garante que o usuário sempre veja o dia atual ao retornar para a visualização de agenda, em vez de manter a data da aba 'Semana'.

A lógica da aba 'Semana' também foi ajustada para garantir que, ao ser selecionada, `currentDate` seja a Segunda-feira da semana e o display de data reflita o intervalo semanal.